### PR TITLE
fix php deprecation - Creation of dynamic property - $device

### DIFF
--- a/src/Ghostscript.php
+++ b/src/Ghostscript.php
@@ -135,6 +135,13 @@ class Ghostscript
     const ANTIALIASING_HIGH   = 4;
 
     /**
+     * This property stores the output-device
+     *
+     * @var string $device
+     */
+    protected $device;
+
+    /**
      * Store the resolution
      *
      * @var string $_resolution


### PR DESCRIPTION
This fixes a PHP (v. 8.2) deprecation warning

 /var/www/html/vendor/org_heigl/ghostscript/src/Ghostscript.php:632

Creation of dynamic property Org_Heigl\Ghostscript\Ghostscript::$device is deprecated